### PR TITLE
Ensure owner authentication for payment card operations

### DIFF
--- a/src/controllers/paymentCardController.ts
+++ b/src/controllers/paymentCardController.ts
@@ -45,7 +45,7 @@ export const deletePaymentCard = async (req: Request, res: Response) => {
   const ownerId = (req as any).user.id;
 
   const paymentCard = await PaymentCard.findById(id);
-  if (paymentCard?.ownerId !== ownerId) {
+  if (paymentCard?.ownerId.toString() !== ownerId) {
     return res.status(403).json({ message: 'Відмовлено у доступі'});
   }
 

--- a/src/controllers/paymentCardController.ts
+++ b/src/controllers/paymentCardController.ts
@@ -1,8 +1,10 @@
 import { Request, Response } from 'express';
 import PaymentCard, { IPaymentCard } from '../models/PaymentCard';
+import exp from "node:constants";
 
 export const addPaymentCard = async (req: Request, res: Response) => {
-  const { cardNumber, expiryDate, ownerName, ownerId } = req.body;
+  const { cardNumber, expiryDate, ownerName } = req.body;
+  const ownerId = (req as any).user.id;
 
   try {
     const newPaymentCard: IPaymentCard = new PaymentCard({
@@ -38,7 +40,14 @@ export const getPaymentCardsByOwnerId = async (req: Request, res: Response) => {
 };
 
 export const deletePaymentCard = async (req: Request, res: Response) => {
+
   const { id } = req.params;
+  const ownerId = (req as any).user.id;
+
+  const paymentCard = await PaymentCard.findById(id);
+  if (paymentCard?.ownerId !== ownerId) {
+    return res.status(403).json({ message: 'Відмовлено у доступі'});
+  }
 
   try {
     const deletedPaymentCard = await PaymentCard.findByIdAndDelete(id);

--- a/src/routes/paymentCardRouter.ts
+++ b/src/routes/paymentCardRouter.ts
@@ -8,7 +8,11 @@ import { authenticateToken } from '../middlewares/authMiddleware';
 
 const router = express.Router();
 
-router.post('/createPaymentCard', addPaymentCard as express.RequestHandler);
+router.post(
+    '/createPaymentCard', 
+    authenticateToken as express.RequestHandler,
+    addPaymentCard as express.RequestHandler
+);
 router.get(
   '/getPaymentCardsByOwnerId',
   authenticateToken as express.RequestHandler,
@@ -16,7 +20,9 @@ router.get(
 );
 router.delete(
   '/deletePaymentCard/:id',
-  deletePaymentCard as express.RequestHandler
+    authenticateToken as express.RequestHandler,
+    deletePaymentCard as express.RequestHandler
+
 );
 
 export default router;


### PR DESCRIPTION
Added `authenticateToken` middleware for create and delete payment card routes to enforce authentication. Modified controller logic to validate that only the owner can perform actions on their payment cards, enhancing security and preventing unauthorized access.